### PR TITLE
Adding other os pkg syscalls

### DIFF
--- a/afero.go
+++ b/afero.go
@@ -91,11 +91,28 @@ type Fs interface {
 	// The name of this FileSystem
 	Name() string
 
-	//Chmod changes the mode of the named file to mode.
+	// Chmod changes the mode of the named file to mode.
 	Chmod(name string, mode os.FileMode) error
 
-	//Chtimes changes the access and modification times of the named file
+	// Chtimes changes the access and modification times of the named file
 	Chtimes(name string, atime time.Time, mtime time.Time) error
+
+	// Link creates newname as a hard link to the oldname file.
+	Link(oldname string, newname string) error
+
+	// Pipe returns a pair of connected files.
+	Pipe() (File, File, error)
+
+	// Setenv sets the value of the environment variable named by the key.
+	Setenv(key string, value string) error
+
+	// Unsetenv unsets the values of the environment variable named by the key.
+	Unsetenv(key string) error
+
+	// Lookupenv retrieves the value of the environment variable named by the key
+	// If the variable is present (value may be empty) boolean true is returned
+	// Otherwise am empty value is returned with boolean false.
+	Lookupenv(key string) (string, bool)
 }
 
 var (

--- a/afero.go
+++ b/afero.go
@@ -109,6 +109,10 @@ type Fs interface {
 	// Unsetenv unsets the values of the environment variable named by the key.
 	Unsetenv(key string) error
 
+	// Getenv retrieves the value of the environment variable named by the key.
+	// If the variable is not present, the value will be empty.
+	Getenv(key string) string
+
 	// Lookupenv retrieves the value of the environment variable named by the key
 	// If the variable is present (value may be empty) boolean true is returned
 	// Otherwise am empty value is returned with boolean false.

--- a/afero_test.go
+++ b/afero_test.go
@@ -713,6 +713,32 @@ func TestSetenv(t *testing.T) {
 	}
 }
 
+func TestUnsetenv(t *testing.T) {
+	for _, fs := range Fss {
+
+		testKey := "testKey"
+		testValue := "testValue"
+
+		// Try to set the value to the key
+		err := fs.Setenv(testKey, testValue)
+		if err != nil {
+			t.Errorf("%v: Value assignment to the key failed: %s", fs.Name(), err)
+		}
+
+		// Try to unset the value to the key
+		err = fs.Unsetenv(testKey)
+		if err != nil {
+			t.Errorf("%v: Value de-assignment to the key failed: %s", fs.Name(), err)
+		}
+
+		// Check if value still exists
+		retrievedValue := fs.Getenv(testKey)
+		if retrievedValue != "" {
+			t.Errorf("%v: Value is not cleared. Retrieved: %s", fs.Name(), retrievedValue)
+		}
+	}
+}
+
 func findNames(fs Fs, t *testing.T, tDir, testSubDir string, root, sub []string) {
 	var foundRoot bool
 	for _, e := range root {

--- a/afero_test.go
+++ b/afero_test.go
@@ -660,16 +660,6 @@ func TestLink(t *testing.T) {
 		if !os.IsNotExist(err) {
 			t.Errorf("%v: Link() didn't raise error for non-existent old path", fs.Name())
 		}
-
-		f, err := fs.Open(tDir)
-		if err != nil {
-			t.Error("TestDir should still exist:", err)
-		}
-
-		names, err := f.Readdirnames(-1)
-		if err != nil {
-			t.Error("Readdirnames failed:", err)
-		}
 	}
 }
 

--- a/afero_test.go
+++ b/afero_test.go
@@ -673,6 +673,26 @@ func TestLink(t *testing.T) {
 	}
 }
 
+func TestPipe(t *testing.T) {
+	for _, fs := range Fss {
+
+		r, w, err := fs.Pipe()
+		if err != nil {
+			t.Errorf("%v: Pipe() failed", fs.Name())
+		}
+
+		_, err = fs.Stat(r)
+		if !os.IsNotExist(err) {
+			t.Errorf("%v: read end of the Pipe() failed: %s", fs.Name(), err)
+		}
+
+		_, err = fs.Stat(w)
+		if !os.IsNotExist(err) {
+			t.Errorf("%v: write end of the Pipe() failed: %s", fs.Name(), err)
+		}
+	}
+}
+
 func findNames(fs Fs, t *testing.T, tDir, testSubDir string, root, sub []string) {
 	var foundRoot bool
 	for _, e := range root {

--- a/afero_test.go
+++ b/afero_test.go
@@ -739,6 +739,43 @@ func TestUnsetenv(t *testing.T) {
 	}
 }
 
+func TestLookupenv(t *testing.T) {
+	for _, fs := range Fss {
+
+		testKey := "testKey"
+		testValue := "testValue"
+
+		// Check if the unset variable exists
+		retVar, present := fs.Lookupenv(testKey)
+		if retVar != nil || present != false {
+			t.Errorf("%v: Found a variable that was never set: %s", fs.Name(), retVar)
+		}
+
+		// Try to set the value to the key
+		err := fs.Setenv(testKey, testValue)
+		if err != nil {
+			t.Errorf("%v: Value assignment to the key failed: %s", fs.Name(), err)
+		}
+
+		retVar, present = fs.Lookupenv(testKey)
+		if retVar != testKey || present != true {
+			t.Errorf("%v: Found a set variable that is not present: %s, found: %s", fs.Name(), testKey, retVar)
+		}
+
+		// Try to unset the value to the key
+		err = fs.Unsetenv(testKey)
+		if err != nil {
+			t.Errorf("%v: Value de-assignment to the key failed: %s", fs.Name(), err)
+		}
+
+		// Check if value still exists
+		retVar, present = fs.Lookupenv(testKey)
+		if retVar != "" || present != false {
+			t.Errorf("%v: Key variable is not cleared: %s", fs.Name(), retVar)
+		}
+	}
+}
+
 func findNames(fs Fs, t *testing.T, tDir, testSubDir string, root, sub []string) {
 	var foundRoot bool
 	for _, e := range root {

--- a/afero_test.go
+++ b/afero_test.go
@@ -693,6 +693,26 @@ func TestPipe(t *testing.T) {
 	}
 }
 
+func TestSetenv(t *testing.T) {
+	for _, fs := range Fss {
+
+		testKey := "testKey"
+		testValue := "testValue"
+
+		// Try to set the value to the key
+		err := fs.Setenv(testKey, testValue)
+		if err != nil {
+			t.Errorf("%v: Value assignment to the key failed: %s", fs.Name(), err)
+		}
+
+		// Check if value is the same as assigned
+		retrievedValue := fs.Getenv(testKey)
+		if testValue != retrievedValue {
+			t.Errorf("%v: Value mismatch failure. Assigned: %s, Retrieved: %s", fs.Name(), testValue, retrievedValue)
+		}
+	}
+}
+
 func findNames(fs Fs, t *testing.T, tDir, testSubDir string, root, sub []string) {
 	var foundRoot bool
 	for _, e := range root {

--- a/basepath.go
+++ b/basepath.go
@@ -142,4 +142,47 @@ func (b *BasePathFs) Create(name string) (f File, err error) {
 	return b.source.Create(name)
 }
 
+func (b *BasePathFs) Getenv(key string) string {
+	if retVal := b.Getenv(key); retVal == "" {
+		return ""
+	}
+	return b.source.Getenv(key)
+}
+
+func (b *BasePathFs) Setenv(key string, value string) error {
+	if err := b.Setenv(key, value); err != nil {
+		return err
+	}
+	return b.source.Setenv(key, value)
+}
+
+func (b *BasePathFs) Unsetenv(key string) error {
+	if err := b.Unsetenv(key); err != nil {
+		return err
+	}
+	return b.source.Unsetenv(key)
+}
+
+func (b *BasePathFs) Link(oldname string, newname string) error {
+	if err := b.Link(oldname, newname); err != nil {
+		return err
+	}
+	return b.source.Link(oldname, newname)
+}
+
+func (b *BasePathFs) Lookupenv(key string) (string, bool) {
+	if retVal, _ := b.Lookupenv(key); retVal == "" {
+		return "", false
+	}
+	return b.source.Lookupenv(key)
+}
+
+func (b *BasePathFs) Pipe() (File, File, error) {
+	r, w, e := b.Pipe()
+	if r == nil || w == nil {
+		return nil, nil, e
+	}
+	return r, w, e
+}
+
 // vim: ts=4 sw=4 noexpandtab nolist syn=go

--- a/cacheOnReadFs.go
+++ b/cacheOnReadFs.go
@@ -294,3 +294,27 @@ func (u *CacheOnReadFs) Create(name string) (File, error) {
 	}
 	return &UnionFile{base: bfh, layer: lfh}, nil
 }
+
+func (u *CacheOnReadFs) Getenv(key string) string {
+	return u.layer.Getenv(key)
+}
+
+func (u *CacheOnReadFs) Link(oldname string, newname string) error {
+	return u.layer.Link(oldname, newname)
+}
+
+func (u *CacheOnReadFs) Setenv(key string, value string) error {
+	return u.layer.Setenv(key, value)
+}
+
+func (u *CacheOnReadFs) Unsetenv(key string) error {
+	return u.layer.Unsetenv(key)
+}
+
+func (u *CacheOnReadFs) Lookupenv(key string) (string, bool) {
+	return u.layer.Lookupenv(key)
+}
+
+func (u *CacheOnReadFs) Pipe() (File, File, error) {
+	return u.layer.Pipe()
+}

--- a/copyOnWriteFs.go
+++ b/copyOnWriteFs.go
@@ -251,3 +251,27 @@ func (u *CopyOnWriteFs) MkdirAll(name string, perm os.FileMode) error {
 func (u *CopyOnWriteFs) Create(name string) (File, error) {
 	return u.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
 }
+
+func (u *CopyOnWriteFs) Getenv(key string) string {
+	return u.layer.Getenv(key)
+}
+
+func (u *CopyOnWriteFs) Link(oldname string, newname string) error {
+	return u.layer.Link(oldname, newname)
+}
+
+func (u *CopyOnWriteFs) Setenv(key string, value string) error {
+	return u.layer.Setenv(key, value)
+}
+
+func (u *CopyOnWriteFs) Unsetenv(key string) error {
+	return u.layer.Unsetenv(key)
+}
+
+func (u *CopyOnWriteFs) Lookupenv(key string) (string, bool) {
+	return u.layer.Lookupenv(key)
+}
+
+func (u *CopyOnWriteFs) Pipe() (File, File, error) {
+	return u.layer.Pipe()
+}

--- a/os.go
+++ b/os.go
@@ -113,6 +113,10 @@ func (OsFs) Unsetenv(key string) error {
 	return os.Unsetenv(key)
 }
 
+func (OsFs) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
 func (OsFs) Lookupenv(key string) (string, bool) {
 	return os.LookupEnv(key)
 }

--- a/os.go
+++ b/os.go
@@ -92,3 +92,27 @@ func (OsFs) Chmod(name string, mode os.FileMode) error {
 func (OsFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	return os.Chtimes(name, atime, mtime)
 }
+
+func (OsFs) Link(oldname string, newname string) error {
+	return os.Link(oldname, newname)
+}
+
+func (OsFs) Pipe() (File, File, error) {
+	r, w, e := os.Pipe()
+	if r == nil || w == nil {
+		return nil, nil, e
+	}
+	return r, w, e
+}
+
+func (OsFs) Setenv(key string, value string) error {
+	return os.Setenv(key, value)
+}
+
+func (OsFs) Unsetenv(key string) error {
+	return os.Unsetenv(key)
+}
+
+func (OsFs) Lookupenv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}


### PR DESCRIPTION
This PR adds the following syscalls:
- `Link()`
- `Pipe()`
- `Setenv()`
- `Unsetenv()`
- `Lookupenv()`
- `Getenv()`

godoc: https://golang.org/pkg/os/

This PR is GPG-signed: D76A3A3A8D7D63F9
Signed-off-by: Simarpreet Singh simar@linux.com
